### PR TITLE
Create seperate ISPC file for neuron update kernel

### DIFF
--- a/bin/genn-buildmodel.bat
+++ b/bin/genn-buildmodel.bat
@@ -7,7 +7,8 @@ goto :genn_begin
 rem :: display genn-buildmodel.bat help
 echo genn-buildmodel.bat script usage:
 echo genn-buildmodel.bat [cdho] model
-echo -c             only generate simulation code for the CPU
+echo -c             generate simulation code for the CPU
+echo -b             generate simulation code for ISPC
 echo -d             enables the debugging mode
 echo -h             shows this help message
 echo -s             build GeNN without SDL checks
@@ -21,7 +22,7 @@ rem :: define genn-buildmodel.bat options separated by spaces
 rem :: -<option>:              option
 rem :: -<option>:""            option with argument
 rem :: -<option>:"<default>"   option with argument and default value
-set "OPTIONS=-o:"%CD%" -i:"" -d: -c: -h: -s: -f: -l:"
+set "OPTIONS=-o:"%CD%" -i:"" -d: -c: -b: -h: -s: -f: -l:"
 for %%O in (%OPTIONS%) do for /f "tokens=1,* delims=:" %%A in ("%%O") do set "%%A=%%~B"
 
 :genn_option
@@ -79,9 +80,15 @@ if defined -d (
         set "MACROS=%MACROS% /p:Configuration=Debug"
         set GENERATOR=.\generator_Debug.exe
     ) else (
-        set "BACKEND_PROJECT=cuda_backend"
-        set "MACROS=%MACROS% /p:Configuration=Debug_CUDA"
-        set GENERATOR=.\generator_Debug_CUDA.exe
+        if defined -b (
+            set "BACKEND_PROJECT=ispc_backend"
+            set "MACROS=%MACROS% /p:Configuration=Debug_ISPC"
+            set GENERATOR=.\generator_Debug_ISPC.exe
+        ) else (
+            set "BACKEND_PROJECT=cuda_backend"
+            set "MACROS=%MACROS% /p:Configuration=Debug_CUDA"
+            set GENERATOR=.\generator_Debug_CUDA.exe
+        )
     )
 ) else (
     set "BACKEND_MACROS= /p:Configuration=Release"
@@ -91,9 +98,15 @@ if defined -d (
         set "MACROS=%MACROS% /p:Configuration=Release"
         set GENERATOR=.\generator_Release.exe
     ) else ( 
-        set "BACKEND_PROJECT=cuda_backend"
-        set "MACROS=%MACROS% /p:Configuration=Release_CUDA"
-        set GENERATOR=.\generator_Release_CUDA.exe
+        if defined -b (
+            set "BACKEND_PROJECT=ispc_backend"
+            set "MACROS=%MACROS% /p:Configuration=Release_ISPC"
+            set GENERATOR=.\generator_Release_ISPC.exe
+        ) else (
+            set "BACKEND_PROJECT=cuda_backend"
+            set "MACROS=%MACROS% /p:Configuration=Release_CUDA"
+            set GENERATOR=.\generator_Release_CUDA.exe
+        )
     )
 )
 

--- a/bin/genn-buildmodel.sh
+++ b/bin/genn-buildmodel.sh
@@ -5,6 +5,7 @@ genn_help () {
     echo "genn-buildmodel.sh script usage:"
     echo "genn-buildmodel.sh [cdho] model"
     echo "-c            generate simulation code for the CPU"
+    echo "-b            generate simulation code for ISCP"
     echo "-p            generate simulation code for HIP"
     echo "-d            enables the debugging mode"
     echo "-m            generate MPI simulation code"
@@ -32,8 +33,9 @@ GENERATOR_MAKEFILE="MakefileCUDA"
 CXX_STANDARD="c++17"
 FORCE_REBUILD=0
 while [[ -n "${!OPTIND}" ]]; do
-    while getopts "clpdvfs:o:i:h" option; do
+    while getopts "cbpdvfs:o:i:h" option; do
     case $option in
+        b) GENERATOR_MAKEFILE="MakefileISPC";;
         c) GENERATOR_MAKEFILE="MakefileSingleThreadedCPU";;
         p) GENERATOR_MAKEFILE="MakefileHIP";;
         d) DEBUG=1;;

--- a/genn.sln
+++ b/genn.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34114.132
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34607.119
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "genn", "src\genn\genn\genn.vcxproj", "{A793E397-1D2F-4E81-8D10-0776A1EBA6DB}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -26,6 +26,12 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "unit", "tests\unit\unit.vcx
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libffi", "src\genn\third_party\libffi\libffi.vcxproj", "{20B1EFDE-150B-4BF5-988F-C1299D492D5D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ispc_backend", "src\genn\backends\ispc\ispc_backend.vcxproj", "{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}"
+	ProjectSection(ProjectDependencies) = postProject
+		{20B1EFDE-150B-4BF5-988F-C1299D492D5D} = {20B1EFDE-150B-4BF5-988F-C1299D492D5D}
+		{A793E397-1D2F-4E81-8D10-0776A1EBA6DB} = {A793E397-1D2F-4E81-8D10-0776A1EBA6DB}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,6 +81,14 @@ Global
 		{20B1EFDE-150B-4BF5-988F-C1299D492D5D}.Release_DLL|x64.Build.0 = Release_DLL|x64
 		{20B1EFDE-150B-4BF5-988F-C1299D492D5D}.Release|x64.ActiveCfg = Release|x64
 		{20B1EFDE-150B-4BF5-988F-C1299D492D5D}.Release|x64.Build.0 = Release|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Debug_DLL|x64.ActiveCfg = Debug_DLL|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Debug_DLL|x64.Build.0 = Debug_DLL|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Debug|x64.ActiveCfg = Debug|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Debug|x64.Build.0 = Debug|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Release_DLL|x64.ActiveCfg = Release_DLL|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Release_DLL|x64.Build.0 = Release_DLL|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Release|x64.ActiveCfg = Release|x64
+		{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/include/genn/backends/ispc/backend.h
+++ b/include/genn/backends/ispc/backend.h
@@ -87,17 +87,17 @@ public:
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
-    virtual void genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const final;
+    virtual void genNeuronUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                  HostHandler preambleHandler) const final;
+    virtual void genSynapseUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged,
+                                  BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const final;
+    virtual void genCustomUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                         HostHandler preambleHandler) const final;
+    virtual void genInit(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                         BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
     virtual size_t getSynapticMatrixRowStride(const SynapseGroupInternal &sg) const final;
 

--- a/include/genn/backends/ispc/backend.h
+++ b/include/genn/backends/ispc/backend.h
@@ -82,7 +82,7 @@ private:
 class BACKEND_EXPORT Backend : public BackendBase
 {
 public:
-    Backend();
+    Backend(const Preferences &preferences);
 
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals

--- a/include/genn/backends/ispc/optimiser.h
+++ b/include/genn/backends/ispc/optimiser.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// PLOG includes
+#include <plog/Severity.h>
+
+// GeNN includes
+#include "backendExport.h"
+
+// ISPC backend includes
+#include "backend.h"
+
+// Forward declarations
+namespace GeNN
+{
+class ModelSpecInternal;
+}
+
+namespace plog
+{
+class IAppender;
+}
+
+//--------------------------------------------------------------------------
+// GeNN::CodeGenerator::ISPC::Optimiser
+//--------------------------------------------------------------------------
+namespace GeNN::CodeGenerator::ISPC::Optimiser
+{
+BACKEND_EXPORT Backend createBackend(const ModelSpecInternal &model, const filesystem::path &outputPath, 
+                                     plog::Severity backendLevel, plog::IAppender *backendAppender,
+                                     const Preferences &preferences);
+}   // namespace GeNN::CodeGenerator::ISPC::Optimiser

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -53,17 +53,17 @@ public:
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
-    virtual void genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const final;
+    virtual void genNeuronUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                  HostHandler preambleHandler) const final;
+    virtual void genSynapseUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                  BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const final;
+    virtual void genCustomUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged,
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                         HostHandler preambleHandler) const final;
+    virtual void genInit(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                         BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
     virtual size_t getSynapticMatrixRowStride(const SynapseGroupInternal &sg) const final;
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -118,6 +118,9 @@ struct PreferencesBase
     }
 };
 
+//! Function backends use to request that new files are created
+using FileStreamCreator = std::function<std::ostream &(const std::string &, const std::string &)>;
+
 //--------------------------------------------------------------------------
 // CodeGenerator::BackendBase
 //--------------------------------------------------------------------------
@@ -155,31 +158,35 @@ public:
     //--------------------------------------------------------------------------
     //! Generate platform-specific function to update the state of all neurons
     /*! \param os                       CodeStream to write function to
+        \param streamCreator            function backend can use to create any additional files required
         \param modelMerged              merged model to generate code for
         \param preambleHandler          callback to write functions for pushing extra-global parameters*/
-    virtual void genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const = 0;
+    virtual void genNeuronUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const = 0;
 
     //! Generate platform-specific function to update the state of all synapses
     /*! \param os                           CodeStream to write function to
+        \param streamCreator            function backend can use to create any additional files required
         \param modelMerged                  merged model to generate code for
         \param preambleHandler              callback to write functions for pushing extra-global parameters*/
-    virtual void genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                  HostHandler preambleHandler) const = 0;
+    virtual void genSynapseUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                  BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const = 0;
 
     //! Generate platform-specific functions to perform custom updates
-    /*! \param os                           CodeStream to write function to
+    /*! \param os                           CodeStream to write function 
+        \param streamCreator            function backend can use to create any additional files required
         \param modelMerged                  merged model to generate code for
         \param preambleHandler              callback to write functions for pushing extra-global parameters*/
-    virtual void genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const = 0;
+    virtual void genCustomUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged,
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const = 0;
 
     //! Generate platform-specific function to initialise model
-    /*! \param os                           CodeStream to write function to
+    /*! \param os                           CodeStream to write function 
+        \param streamCreator                function backend can use to create any additional files required
         \param modelMerged                  merged model to generate code for
         \param preambleHandler              callback to write functions for pushing extra-global parameters*/
-    virtual void genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                         HostHandler preambleHandler) const = 0;
+    virtual void genInit(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                         BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const = 0;
 
     //! Gets the stride used to access synaptic matrix rows, taking into account sparse data structure, padding etc
     virtual size_t getSynapticMatrixRowStride(const SynapseGroupInternal &sg) const = 0;

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -98,17 +98,17 @@ public:
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
-    virtual void genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const final;
+    virtual void genNeuronUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                  HostHandler preambleHandler) const final;
+    virtual void genSynapseUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                                  BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                 HostHandler preambleHandler) const final;
+    virtual void genCustomUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged,
+                                 BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
-    virtual void genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                         HostHandler preambleHandler) const final;
+    virtual void genInit(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                         BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const final;
 
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;

--- a/include/genn/genn/code_generator/generateModules.h
+++ b/include/genn/genn/code_generator/generateModules.h
@@ -26,19 +26,21 @@ namespace filesystem
 //--------------------------------------------------------------------------
 namespace GeNN::CodeGenerator
 {
+using FileStreamCreator = std::function<std::ostream &(const std::string &, const std::string &)>;
+
 GENN_EXPORT std::vector<std::string> generateAll(ModelSpecMerged &modelMerged, const BackendBase &backend, 
                                                  const filesystem::path &outputPath, bool alwaysRebuild = false, 
                                                  bool neverRebuild = false);
 
-GENN_EXPORT void generateNeuronUpdate(std::ostream &stream, ModelSpecMerged &modelMerged, const BackendBase &backend,
+GENN_EXPORT void generateNeuronUpdate(FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, const BackendBase &backend,
                                       BackendBase::MemorySpaces &memorySpaces, const std::string &suffix = "");
 
-GENN_EXPORT void generateCustomUpdate(std::ostream &stream, ModelSpecMerged &modelMerged, const BackendBase &backend, 
+GENN_EXPORT void generateCustomUpdate(FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, const BackendBase &backend,
                                       BackendBase::MemorySpaces &memorySpaces, const std::string &suffix = "");
 
-GENN_EXPORT void generateSynapseUpdate(std::ostream &stream, ModelSpecMerged &modelMerged, const BackendBase &backend, 
+GENN_EXPORT void generateSynapseUpdate(FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, const BackendBase &backend,
                                        BackendBase::MemorySpaces &memorySpaces, const std::string &suffix = "");
 
-GENN_EXPORT void generateInit(std::ostream &stream, ModelSpecMerged &modelMerged, const BackendBase &backend, 
+GENN_EXPORT void generateInit(FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, const BackendBase &backend,
                               BackendBase::MemorySpaces &memorySpaces, const std::string &suffix = "");
 }

--- a/include/genn/genn/code_generator/generateModules.h
+++ b/include/genn/genn/code_generator/generateModules.h
@@ -26,8 +26,6 @@ namespace filesystem
 //--------------------------------------------------------------------------
 namespace GeNN::CodeGenerator
 {
-using FileStreamCreator = std::function<std::ostream &(const std::string &, const std::string &)>;
-
 GENN_EXPORT std::vector<std::string> generateAll(ModelSpecMerged &modelMerged, const BackendBase &backend, 
                                                  const filesystem::path &outputPath, bool alwaysRebuild = false, 
                                                  bool neverRebuild = false);

--- a/src/genn/backends/ispc/backend.cc
+++ b/src/genn/backends/ispc/backend.cc
@@ -179,19 +179,18 @@ Backend::Backend(const Preferences &preferences)
 {
 }
 
-void Backend::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                              HostHandler preambleHandler) const
+void Backend::genNeuronUpdate(CodeStream &os, FileStreamCreator streamCreator, ModelSpecMerged &modelMerged, 
+                              BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     if(modelMerged.getModel().getBatchSize() != 1) {
         throw std::runtime_error("The ISPC backend only supports simulations with a batch size of 1");
     }
-   
-    // Generate stream with neuron update code
-    std::ostringstream neuronUpdateStream;
-    CodeStream neuronUpdate(neuronUpdateStream);
 
+    // Create seperate stream for ISPC file
+    CodeStream neuronUpdateISPC(streamCreator("neuronUpdate", "ispc"));
+   
     // Begin environment with standard library
-    EnvironmentLibrary backendEnv(neuronUpdate, backendFunctions);
+    EnvironmentLibrary backendEnv(neuronUpdateISPC, backendFunctions);
     EnvironmentLibrary neuronUpdateEnv(backendEnv, StandardLibrary::getMathsFunctions());
 
     neuronUpdateEnv.getStream() << "void updateNeurons(" << modelMerged.getModel().getTimePrecision().getName() << " t";
@@ -389,19 +388,17 @@ void Backend::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
 
     // Generate preamble
     preambleHandler(os);
-
-    os << neuronUpdateStream.str();
 }
 
-void Backend::genSynapseUpdate(CodeStream &, ModelSpecMerged &, BackendBase::MemorySpaces &, HostHandler) const
+void Backend::genSynapseUpdate(CodeStream &, FileStreamCreator, ModelSpecMerged &, BackendBase::MemorySpaces &, HostHandler) const
 {
 }
 
-void Backend::genCustomUpdate(CodeStream &, ModelSpecMerged &, BackendBase::MemorySpaces &, HostHandler) const
+void Backend::genCustomUpdate(CodeStream &, FileStreamCreator, ModelSpecMerged &, BackendBase::MemorySpaces &, HostHandler) const
 {
 }
 
-void Backend::genInit(CodeStream &, ModelSpecMerged &, BackendBase::MemorySpaces &, HostHandler) const
+void Backend::genInit(CodeStream &, FileStreamCreator, ModelSpecMerged &, BackendBase::MemorySpaces &, HostHandler) const
 {
 }
 

--- a/src/genn/backends/ispc/ispc_backend.vcxproj
+++ b/src/genn/backends/ispc/ispc_backend.vcxproj
@@ -20,9 +20,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="backend.cc" />
+    <ClCompile Include="optimiser.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\genn\backends\ispc\backend.h" />
+    <ClInclude Include="..\..\..\..\include\genn\backends\ispc\optimiser.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{14E2399B-B5DB-4F3F-AFF5-8CB4E92E5C22}</ProjectGuid>

--- a/src/genn/backends/ispc/optimiser.cc
+++ b/src/genn/backends/ispc/optimiser.cc
@@ -1,0 +1,23 @@
+#include "optimiser.h"
+
+//--------------------------------------------------------------------------
+// GeNN::CodeGenerator::ISPC::Optimiser
+//--------------------------------------------------------------------------
+namespace GeNN::CodeGenerator::ISPC::Optimiser
+{
+Backend createBackend(const ModelSpecInternal&,const filesystem::path&,
+                      plog::Severity backendLevel, plog::IAppender *backendAppender, 
+                      const Preferences &preferences)
+{
+    // If there isn't already a plog instance, initialise one
+    if(plog::get<Logging::CHANNEL_BACKEND>() == nullptr) {
+        plog::init<Logging::CHANNEL_BACKEND>(backendLevel, backendAppender);
+    }
+    // Otherwise, set it's max severity from GeNN preferences
+    else {
+        plog::get<Logging::CHANNEL_BACKEND>()->setMaxSeverity(backendLevel);
+    }
+
+    return Backend(preferences);
+}
+}   // namespace GeNN::CodeGenerator::SingleThreadedCPU::Optimiser

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -216,8 +216,8 @@ void genRemap(EnvironmentExternalBase &env)
 //--------------------------------------------------------------------------
 namespace GeNN::CodeGenerator::SingleThreadedCPU
 {
-void Backend::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                              HostHandler preambleHandler) const
+void Backend::genNeuronUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged, 
+                              BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     if(modelMerged.getModel().getBatchSize() != 1) {
         throw std::runtime_error("The single-threaded CPU backend only supports simulations with a batch size of 1");
@@ -429,8 +429,8 @@ void Backend::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
     os << neuronUpdateStream.str();
 }
 //--------------------------------------------------------------------------
-void Backend::genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                               HostHandler preambleHandler) const
+void Backend::genSynapseUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged, 
+                               BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     if (modelMerged.getModel().getBatchSize() != 1) {
         throw std::runtime_error("The single-threaded CPU backend only supports simulations with a batch size of 1");
@@ -634,8 +634,8 @@ void Backend::genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Bac
     os << synapseUpdateStream.str();
 }
 //--------------------------------------------------------------------------
-void Backend::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                              HostHandler preambleHandler) const
+void Backend::genCustomUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged, 
+                              BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     const ModelSpecInternal &model = modelMerged.getModel();
 
@@ -996,8 +996,8 @@ void Backend::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
 
 }
 //--------------------------------------------------------------------------
-void Backend::genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                      HostHandler preambleHandler) const
+void Backend::genInit(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged,
+                      BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     const ModelSpecInternal &model = modelMerged.getModel();
     if(model.getBatchSize() != 1) {

--- a/src/genn/generator/MakefileISPC
+++ b/src/genn/generator/MakefileISPC
@@ -1,0 +1,6 @@
+# Configure for ISPC backend
+BACKEND_NAME        :=ispc
+BACKEND_NAMESPACE   :=ISPC
+
+# Include common makefile
+include MakefileCommon

--- a/src/genn/generator/generator.vcxproj
+++ b/src/genn/generator/generator.vcxproj
@@ -5,8 +5,8 @@
       <Configuration>Debug_CUDA</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug_OpenCL|x64">
-      <Configuration>Debug_OpenCL</Configuration>
+    <ProjectConfiguration Include="Debug_ISPC|x64">
+      <Configuration>Debug_ISPC</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
@@ -17,8 +17,8 @@
       <Configuration>Release_CUDA</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release_OpenCL|x64">
-      <Configuration>Release_OpenCL</Configuration>
+    <ProjectConfiguration Include="Release_ISPC|x64">
+      <Configuration>Release_ISPC</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
@@ -45,7 +45,7 @@
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_OpenCL|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ISPC|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
@@ -58,14 +58,14 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_CUDA|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_ISPC|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_OpenCL|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_CUDA|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
@@ -114,19 +114,19 @@
       <AdditionalLibraryDirectories>..\..\..\lib;$(CUDA_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_OpenCL|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ISPC|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\include\genn\backends\opencl;..\..\..\include\genn\genn;..\..\..\include\genn\third_party;..\..\..\include\genn\third_party\libffi;$(OPENCL_PATH)\include;$(BuildModelInclude)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;FFI_BUILDING;_CRT_SECURE_NO_WARNINGS;BACKEND_NAMESPACE=OpenCL;BACKEND_NAME=opencl;CL_HPP_TARGET_OPENCL_VERSION=120;CL_HPP_MINIMUM_OPENCL_VERSION=120;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
+      <SDLCheck>$(BuildModelSDLCheck)</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\include\genn\backends\ispc;..\..\..\include\genn\genn;..\..\..\include\genn\third_party;..\..\..\include\genn\third_party\libffi;$(BuildModelInclude)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;FFI_BUILDING;_CRT_SECURE_NO_WARNINGS;BACKEND_NAMESPACE=ISPC;BACKEND_NAME=ispc;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libffi_Debug.lib;genn_Debug.lib;genn_opencl_backend_Debug.lib;OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\lib;$(OPENCL_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libffi_Debug.lib;genn_Debug.lib;genn_ispc_backend_Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -167,23 +167,23 @@
       <AdditionalLibraryDirectories>..\..\..\lib;$(CUDA_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_OpenCL|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_ISPC|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\include\genn\backends\opencl;..\..\..\include\genn\genn;..\..\..\include\genn\third_party;..\..\..\include\genn\third_party\libffi;$(OPENCL_PATH)\include;$(BuildModelInclude)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;_CRT_SECURE_NO_WARNINGS;FFI_BUILDING;BACKEND_NAMESPACE=OpenCL;BACKEND_NAME=opencl;CL_HPP_TARGET_OPENCL_VERSION=120;CL_HPP_MINIMUM_OPENCL_VERSION=120;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
+      <SDLCheck>$(BuildModelSDLCheck)</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\include\genn\backends\ispc;..\..\..\include\genn\genn;..\..\..\include\genn\third_party;..\..\..\include\genn\third_party\libffi;$(BuildModelInclude)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;FFI_BUILDING;_CRT_SECURE_NO_WARNINGS;BACKEND_NAMESPACE=ISPC;BACKEND_NAME=ispc;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>libffi_Release.lib;genn_Release.lib;genn_opencl_backend_Release.lib;OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\lib;$(OPENCL_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libffi_Release.lib;genn_Release.lib;genn_ispc_backend_Release.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/genn/genn/code_generator/backendCUDAHIP.cc
+++ b/src/genn/genn/code_generator/backendCUDAHIP.cc
@@ -302,8 +302,8 @@ void BackendCUDAHIP::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<C
     ::buildPopulationRNGEnvironment(env, getRandPrefix(), getPopulationRNGInternalType());
 }
 //--------------------------------------------------------------------------
-void BackendCUDAHIP::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                     HostHandler preambleHandler) const
+void BackendCUDAHIP::genNeuronUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged, 
+                                     BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     const ModelSpecInternal &model = modelMerged.getModel();
 
@@ -447,8 +447,8 @@ void BackendCUDAHIP::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerge
     os << neuronUpdateStream.str();
 }
 //--------------------------------------------------------------------------
-void BackendCUDAHIP::genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                      HostHandler preambleHandler) const
+void BackendCUDAHIP::genSynapseUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged,
+                                      BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     // Generate stream with synapse update code
     std::ostringstream synapseUpdateStream;
@@ -619,8 +619,8 @@ void BackendCUDAHIP::genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerg
 
 }
 //--------------------------------------------------------------------------
-void BackendCUDAHIP::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                                     HostHandler preambleHandler) const
+void BackendCUDAHIP::genCustomUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged,
+                                     BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     const ModelSpecInternal &model = modelMerged.getModel();
 
@@ -876,8 +876,8 @@ void BackendCUDAHIP::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerge
     os << customUpdateStream.str();
 }
 //--------------------------------------------------------------------------
-void BackendCUDAHIP::genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase::MemorySpaces &memorySpaces, 
-                             HostHandler preambleHandler) const
+void BackendCUDAHIP::genInit(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged, 
+                             BackendBase::MemorySpaces &memorySpaces, HostHandler preambleHandler) const
 {
     const ModelSpecInternal &model = modelMerged.getModel();
 

--- a/src/genn/genn/code_generator/generateModules.cc
+++ b/src/genn/genn/code_generator/generateModules.cc
@@ -159,7 +159,7 @@ void generateNeuronUpdate(FileStreamCreator streamCreator, ModelSpecMerged &mode
     neuronUpdate << std::endl;
 
     // Neuron update kernel
-    backend.genNeuronUpdate(neuronUpdate, modelMerged, memorySpaces,
+    backend.genNeuronUpdate(neuronUpdate, streamCreator, modelMerged, memorySpaces,
         // Preamble handler
         [&modelMerged, &backend](CodeStream &os)
         {
@@ -179,7 +179,7 @@ void generateCustomUpdate(FileStreamCreator streamCreator, ModelSpecMerged &mode
     customUpdate << std::endl;
 
     // Neuron update kernel
-    backend.genCustomUpdate(customUpdate, modelMerged, memorySpaces,
+    backend.genCustomUpdate(customUpdate, streamCreator, modelMerged, memorySpaces,
         // Preamble handler
         [&modelMerged, &backend](CodeStream &os)
         {
@@ -202,7 +202,7 @@ void generateSynapseUpdate(FileStreamCreator streamCreator, ModelSpecMerged &mod
     synapseUpdate << std::endl;
 
     // Synaptic update kernels
-    backend.genSynapseUpdate(synapseUpdate, modelMerged, memorySpaces,
+    backend.genSynapseUpdate(synapseUpdate, streamCreator, modelMerged, memorySpaces,
         // Preamble handler
         [&modelMerged, &backend](CodeStream &os)
         {
@@ -221,7 +221,7 @@ void generateInit(FileStreamCreator streamCreator, ModelSpecMerged &modelMerged,
 
     init << "#include \"definitions" << suffix << ".h\"" << std::endl;
 
-    backend.genInit(init, modelMerged, memorySpaces,
+    backend.genInit(init, streamCreator, modelMerged, memorySpaces,
         // Preamble handler
         [&modelMerged, &memorySpaces, &backend](CodeStream &os)
         {


### PR DESCRIPTION
The ISPC compiler can _only_ compile ISPC code, C++ helper functions like the ones that get generated by these:
```c++
// Generate struct definitions
modelMerged.genMergedNeuronUpdateGroupStructs(os, *this);
modelMerged.genMergedNeuronSpikeQueueUpdateStructs(os, *this);
modelMerged.genMergedNeuronPrevSpikeTimeUpdateStructs(os, *this);

// Generate arrays of merged structs and functions to set them
modelMerged.genMergedNeuronUpdateGroupHostStructArrayPush(os, *this);
modelMerged.genMergedNeuronSpikeQueueUpdateHostStructArrayPush(os, *this);
modelMerged.genMergedNeuronPrevSpikeTimeUpdateHostStructArrayPush(os, *this);
```
at the bottom of your ``genNeuronUpdate`` function need to go in a .cc file (and get compiled with the standard C++ compiler) and the actual ISPC kernels need to go into a seperate .ispc file (which will get compiled with the ISPC compiler).  Using https://github.com/genn-team/genn/pull/693, I've implemented this (you should merge #1 first)