### PR TITLE
Improve makefile generation

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -255,7 +255,7 @@ public:
                                                   const Type::ResolvedType &type, const std::string &name, VarLocation loc, 
                                                   const std::string &countVarName) const final;
 
-    virtual void genMakefilePreamble(std::ostream &os) const final;
+    virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
 

--- a/include/genn/backends/ispc/backend.h
+++ b/include/genn/backends/ispc/backend.h
@@ -153,7 +153,7 @@ public:
     
     virtual void genAssert(CodeStream &os, const std::string &condition) const final;
 
-    virtual void genMakefilePreamble(std::ostream &os) const final;
+    virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -133,7 +133,7 @@ public:
      //! On backends which support it, generate a runtime assert
     virtual void genAssert(CodeStream &os, const std::string &condition) const final;
 
-    virtual void genMakefilePreamble(std::ostream &os) const final;
+    virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -272,7 +272,7 @@ public:
     virtual void genAssert(CodeStream &os, const std::string &condition) const = 0;
 
     //! This function can be used to generate a preamble for the GNU makefile used to build
-    virtual void genMakefilePreamble(std::ostream &os) const = 0;
+    virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const = 0;
 
     //! The GNU make build system will populate a variable called ``$(OBJECTS)`` with a list of objects to link.
     //! This function should generate a GNU make rule to build these objects into a shared library.

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -364,7 +364,7 @@ void Backend::genLazyVariableDynamicAllocation(CodeStream &os, const Type::Resol
     }
 }
 //--------------------------------------------------------------------------
-void Backend::genMakefilePreamble(std::ostream &os) const
+void Backend::genMakefilePreamble(std::ostream &os, const std::vector<std::string>&) const
 {
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
     std::string linkFlags = "--shared -arch " + architecture;

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -380,7 +380,7 @@ void Backend::genLazyVariableDynamicAllocation(CodeStream &os, const Type::Resol
     }
 }
 //--------------------------------------------------------------------------
-void Backend::genMakefilePreamble(std::ostream &os) const
+void Backend::genMakefilePreamble(std::ostream &os, const std::vector<std::string>&) const
 {
     const std::string architecture = "sm_" + std::to_string(getChosenHIPDevice().major) + std::to_string(getChosenHIPDevice().minor);
     std::string linkFlags = "--shared -arch " + architecture;

--- a/src/genn/backends/ispc/backend.cc
+++ b/src/genn/backends/ispc/backend.cc
@@ -559,7 +559,7 @@ void Backend::genAssert(CodeStream &os, const std::string &condition) const
     os << "assert(" << condition << ");" << std::endl;
 }
 
-void Backend::genMakefilePreamble(std::ostream &os) const
+void Backend::genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const
 {
     std::string linkFlags = "-shared ";
     std::string cxxFlags = "-c -fPIC -std=c++11 -MMD -MP";
@@ -583,9 +583,13 @@ void Backend::genMakefilePreamble(std::ostream &os) const
     os << "ISPC := ispc" << std::endl;
     os << "ISPCFLAGS := -O2 --target=" << ispcPrefs.targetISA << std::endl;
     
-    // Add OBJECTS variable to include all object files
-    os << "OBJECTS := neuronUpdate.o synapseUpdate.o customUpdate.o init.o" << std::endl;
-    
+    // Add ISPC objects
+    os << "OBJECTS += ";
+    for(const auto &m : moduleNames) {
+        if(m != "runner") {
+            os << m << "ISPC.o ";
+        }
+    }
     os << std::endl;
 }
 
@@ -602,7 +606,7 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(CXX) $(CXXFLAGS) -o $@ $<" << std::endl;
     
     // Rule for compiling ISPC files
-    os << "%.o: %.ispc" << std::endl;
+    os << "%ISPC.o: %.ispc" << std::endl;
     os << "\t@$(ISPC) $(ISPCFLAGS) -o $@ -h $(@:.o=.h) $<" << std::endl;
     
     // Add dependency generation rule

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1638,7 +1638,7 @@ void Backend::genAssert(CodeStream &os, const std::string &condition) const
     os << "assert(" << condition << ");" << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genMakefilePreamble(std::ostream &os) const
+void Backend::genMakefilePreamble(std::ostream &os, const std::vector<std::string>&) const
 {
     std::string linkFlags = "-shared ";
     std::string cxxFlags = "-c -fPIC -std=c++11 -MMD -MP";

--- a/src/genn/genn/code_generator/generateMakefile.cc
+++ b/src/genn/genn/code_generator/generateMakefile.cc
@@ -25,7 +25,7 @@ void GeNN::CodeGenerator::generateMakefile(std::ostream &os, const BackendBase &
     os << std::endl;
 
     // Generate make file preamble
-    backend.genMakefilePreamble(os);
+    backend.genMakefilePreamble(os, moduleNames);
     os << std::endl;
 
     // Apply substitution to generate dependency list


### PR DESCRIPTION
The makefiles you were generating previous created .o files with the same name for ISPC and C++ modules. I now build a seperate list. This might also have been possible to do in pure GNU make but this works for now.