### PR TITLE
Fixes

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -255,9 +255,15 @@ public:
                                                   const Type::ResolvedType &type, const std::string &name, VarLocation loc, 
                                                   const std::string &countVarName) const final;
 
+    virtual bool shouldUseNMakeBuildSystem() const final;
+
     virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
+
+    virtual void genNMakefilePreamble(std::ostream &os) const final;
+    virtual void genNMakefileLinkRule(std::ostream &os) const final;
+    virtual void genNMakefileCompileRule(std::ostream &os) const final;
 
     virtual void genMSBuildConfigProperties(std::ostream &os) const final;
     virtual void genMSBuildImportProps(std::ostream &os) const final;

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -261,7 +261,7 @@ public:
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
 
-    virtual void genNMakefilePreamble(std::ostream &os) const final;
+    virtual void genNMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genNMakefileLinkRule(std::ostream &os) const final;
     virtual void genNMakefileCompileRule(std::ostream &os) const final;
 

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -183,10 +183,16 @@ public:
     virtual void genLazyVariableDynamicAllocation(CodeStream &os, 
                                                   const Type::ResolvedType &type, const std::string &name, VarLocation loc, 
                                                   const std::string &countVarName) const final;
+    
+    virtual bool shouldUseNMakeBuildSystem() const final{ return true; }
 
     virtual void genMakefilePreamble(std::ostream &os) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
+    
+    virtual void genNMakefilePreamble(std::ostream &os) const final;
+    virtual void genNMakefileLinkRule(std::ostream &os) const final;
+    virtual void genNMakefileCompileRule(std::ostream &os) const final;
 
     virtual void genMSBuildConfigProperties(std::ostream &os) const final;
     virtual void genMSBuildImportProps(std::ostream &os) const final;

--- a/include/genn/backends/ispc/backend.h
+++ b/include/genn/backends/ispc/backend.h
@@ -153,9 +153,15 @@ public:
     
     virtual void genAssert(CodeStream &os, const std::string &condition) const final;
 
+    virtual bool shouldUseNMakeBuildSystem() const final{ return true; }
+
     virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
+
+    virtual void genNMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
+    virtual void genNMakefileLinkRule(std::ostream &os) const final;
+    virtual void genNMakefileCompileRule(std::ostream &os) const final;
 
     virtual void genMSBuildConfigProperties(std::ostream &os) const final;
     virtual void genMSBuildImportProps(std::ostream &os) const final;

--- a/include/genn/backends/ispc/backend.h
+++ b/include/genn/backends/ispc/backend.h
@@ -180,8 +180,6 @@ public:
 
     virtual std::string getRestrictKeyword() const override{ return ""; }
     
-    virtual std::string getUniformKeyword() const override{ return "uniform "; }
-    
     virtual MemorySpaces getMergedGroupMemorySpaces(const ModelSpecMerged &modelMerged) const final;
     
     virtual boost::uuids::detail::sha1::digest_type getHashDigest() const final;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -123,10 +123,6 @@ public:
     //! "restricted" i.e. not aliased. What keyword should be used to indicate this?
     virtual std::string getRestrictKeyword() const final;
 
-    //! Some backends require qualifiers to ensure struct members have consistent values
-    //! across parallel execution units. What keyword should be used to indicate this?
-    virtual std::string getUniformKeyword() const final;
-
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const final;
     virtual void genTimer(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free, CodeStream &stepTimeFinalise, 
                           const std::string &name, bool updateInStepTime) const final;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -137,9 +137,15 @@ public:
      //! On backends which support it, generate a runtime assert
     virtual void genAssert(CodeStream &os, const std::string &condition) const final;
 
+    virtual bool shouldUseNMakeBuildSystem() const final{ return false; }
+
     virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
+
+    virtual void genNMakefilePreamble(std::ostream &os) const final;
+    virtual void genNMakefileLinkRule(std::ostream &os) const final;
+    virtual void genNMakefileCompileRule(std::ostream &os) const final;
 
     virtual void genMSBuildConfigProperties(std::ostream &os) const final;
     virtual void genMSBuildImportProps(std::ostream &os) const final;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -139,7 +139,7 @@ public:
     virtual void genMakefileLinkRule(std::ostream &os) const final;
     virtual void genMakefileCompileRule(std::ostream &os) const final;
 
-    virtual void genNMakefilePreamble(std::ostream &os) const final;
+    virtual void genNMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const final;
     virtual void genNMakefileLinkRule(std::ostream &os) const final;
     virtual void genNMakefileCompileRule(std::ostream &os) const final;
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -258,10 +258,6 @@ public:
     //! "restricted" i.e. not aliased. What keyword should be used to indicate this?
     virtual std::string getRestrictKeyword() const = 0;
 
-    //! Some backends require qualifiers to ensure struct members have consistent values
-    //! across parallel execution units. What keyword should be used to indicate this?
-    virtual std::string getUniformKeyword() const = 0;
-
     //! Generate a single RNG instance
     /*! On single-threaded platforms this can be a standard RNG like M.T. but, on parallel platforms, it is likely to be a counter-based RNG */
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const = 0;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -275,6 +275,10 @@ public:
     //! On backends which support it, generate a runtime assert
     virtual void genAssert(CodeStream &os, const std::string &condition) const = 0;
 
+    //! On Windows, there are two choices of build system MSBuild and NMake. MSBuild is much better, offering parallel builds, 
+    //! Dependency tracking etc but various backends do not provide MSBuild plugins and sometimes these don't get installed
+    virtual bool shouldUseNMakeBuildSystem() const = 0;
+
     //! This function can be used to generate a preamble for the GNU makefile used to build
     virtual void genMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const = 0;
 
@@ -285,6 +289,17 @@ public:
     //! The GNU make build system uses 'pattern rules' (https://www.gnu.org/software/make/manual/html_node/Pattern-Intro.html) to build backend modules into objects.
     //! This function should generate a GNU make pattern rule capable of building each module (i.e. compiling .cc file $< into .o file $@).
     virtual void genMakefileCompileRule(std::ostream &os) const = 0;
+
+    //! This function can be used to generate a preamble for the NMAKE makefile used to build
+    virtual void genNMakefilePreamble(std::ostream &os) const = 0;
+
+    //! The NMAKE build system will populate a variable called ``$(OBJECTS)`` with a list of objects to link.
+    //! This function should generate a NMAKE rule to build these objects into a DLL
+    virtual void genNMakefileLinkRule(std::ostream &os) const = 0;
+
+    //! The NMAKE build system uses 'inference rules' (https://learn.microsoft.com/en-us/cpp/build/reference/inference-rules?view=msvc-170) to build backend modules into objects.
+    //! This function should generate an NMAKE pattern rule capable of building each module (i.e. compiling .cc file $< into .obj file $@).
+    virtual void genNMakefileCompileRule(std::ostream &os) const = 0;
 
     //! In MSBuild, 'properties' are used to configure global project settings e.g. whether the MSBuild project builds a static or dynamic library
     //! This function can be used to add additional XML properties to this section.

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -287,7 +287,7 @@ public:
     virtual void genMakefileCompileRule(std::ostream &os) const = 0;
 
     //! This function can be used to generate a preamble for the NMAKE makefile used to build
-    virtual void genNMakefilePreamble(std::ostream &os) const = 0;
+    virtual void genNMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const = 0;
 
     //! The NMAKE build system will populate a variable called ``$(OBJECTS)`` with a list of objects to link.
     //! This function should generate a NMAKE rule to build these objects into a DLL

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -139,10 +139,6 @@ public:
     //! "restricted" i.e. not aliased. What keyword should be used to indicate this?
     virtual std::string getRestrictKeyword() const final;
 
-    //! Some backends require qualifiers to ensure struct members have consistent values
-    //! across parallel execution units. What keyword should be used to indicate this?
-    virtual std::string getUniformKeyword() const final;
-
     //! Generate a single RNG instance
     /*! On single-threaded platforms this can be a standard RNG like M.T. but, on parallel platforms, it is likely to be a counter-based RNG */
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const final;

--- a/include/genn/genn/code_generator/generateNMakefile.h
+++ b/include/genn/genn/code_generator/generateNMakefile.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Standard C++ includes
 #include <string>
 #include <vector>
@@ -21,5 +23,6 @@ class BackendBase;
 //--------------------------------------------------------------------------
 namespace GeNN::CodeGenerator
 {
-GENN_EXPORT void generateMSBuild(std::ostream &os, const BackendBase &backend, const std::vector<std::string> &moduleNames);
+GENN_EXPORT void generateNMakefile(std::ostream &os, const BackendBase &backend,
+                                   const std::vector<std::string> &moduleNames);
 }

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -235,11 +235,6 @@ public:
             CodeStream::Scope b(os);
             const auto sortedFields = getSortedFields(backend);
             for(const auto &f : sortedFields) {
-                // Add backend-specific qualifier for consistent values across parallel execution units
-                if(!host) {
-                    os << backend.getUniformKeyword();
-                }
-                
                 // If field is a pointer
                 if(f.type.isPointer()) {
                     os << f.type.getName();

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -682,12 +682,15 @@ class GeNNModel(ModelSpec):
         # Build code
         if not never_rebuild:
             if system() == "Windows":
-                debug = self._preference_kwargs.get("debug_code", False)
-                check_call(
-                    [_msbuild, 
-                     f"/p:Configuration={'Debug' if debug else 'Release'}",
-                     "/m", "/verbosity:quiet",
-                     path.join(output_path, "runner.vcxproj")])
+                if self._backend.should_use_nmake_build_system:
+                    check_call(["nmake"], cwd=output_path)
+                else:
+                    debug = self._preference_kwargs.get("debug_code", False)
+                    check_call(
+                        [_msbuild, 
+                         f"/p:Configuration={'Debug' if debug else 'Release'}",
+                         "/m", "/verbosity:quiet",
+                         path.join(output_path, "runner.vcxproj")])
             else:
                 check_call(["make", "-j", str(cpu_count(logical=False)), "-C", output_path])
 

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -683,7 +683,7 @@ class GeNNModel(ModelSpec):
         if not never_rebuild:
             if system() == "Windows":
                 if self._backend.should_use_nmake_build_system:
-                    check_call(["nmake"], cwd=output_path)
+                    check_call(["nmake", "/NOLOGO"], cwd=output_path)
                 else:
                     debug = self._preference_kwargs.get("debug_code", False)
                     check_call(

--- a/setup.py
+++ b/setup.py
@@ -125,11 +125,12 @@ backends = [("single_threaded_cpu", "singleThreadedCPU", {})]
 # If CUDA was found, add backend configuration
 if cuda_installed:
     # Get CUDA library directory
+    # **NOTE** $(CUDA_PATH)/lib/x64 is correct for system CUDA installs on Windows but not conda
     cuda_library_dirs = []
     if MACOS:
         cuda_library_dirs.append(os.path.join(cuda_path, "lib"))
     elif WIN:
-        cuda_library_dirs.append(os.path.join(cuda_path, "lib", "x64"))
+        cuda_library_dirs.append(os.environ.get("CudaLibraryPath", os.path.join(cuda_path, "lib", "x64")))
     else:
         cuda_library_dirs.append(os.path.join(cuda_path, "lib64"))
 

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -421,7 +421,7 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(NVCC) -dc $(NVCCFLAGS) $<" << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genNMakefilePreamble(std::ostream &os) const
+void Backend::genNMakefilePreamble(std::ostream &os, const std::vector<std::string>&) const
 {
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
     std::string linkFlags = "--shared -arch " + architecture;

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -435,6 +435,9 @@ void Backend::genNMakefilePreamble(std::ostream &os) const
 void Backend::genNMakefileLinkRule(std::ostream &os) const
 {
     // Use Visual C++ linker to link objects with device object code
+    // **NOTE** link.exe doesn't seem to care if LIBPATH exists or not.
+    // Anaconda adds its library directory to the LIB environment variable
+    // which gets searched after /LIBPATH
     // **YUCK** there should be some way to do this with $(CXX) /LINK
     os << "runner.dll: $(OBJECTS) runner_dlink.obj" << std::endl;
 	os << "\t@link.exe /OUT:runner.dll /LIBPATH:\"$(CUDA_PATH)\\lib\\x64\" cudart_static.lib  cudart.lib cudadevrt.lib /DLL $(OBJECTS) runner_dlink.obj" << std::endl;

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -7,6 +7,9 @@
 // CUDA includes
 #include <curand_kernel.h>
 
+// Filesystem includes
+#include "path.h"
+
 // GeNN includes
 #include "gennUtils.h"
 #include "logging.h"
@@ -364,6 +367,27 @@ void Backend::genLazyVariableDynamicAllocation(CodeStream &os, const Type::Resol
     }
 }
 //--------------------------------------------------------------------------
+bool Backend::shouldUseNMakeBuildSystem() const
+{
+     // Get CUDA_PATH environment variable
+    filesystem::path nvccPath;
+    if(const char *cudaPath = std::getenv("CUDA_PATH")) {
+        // Get CUDA version
+        int cudaVersion;
+        CHECK_CUDA_ERRORS(cudaRuntimeGetVersion(&cudaVersion));
+
+        // Split into major and minor version
+        const auto majorMinor = std::div(cudaVersion, 1000);
+
+        // Determine if props file exists
+        const std::string propsFile = "CUDA " + std::to_string(majorMinor.quot) + "." + std::to_string(majorMinor.rem / 10) + ".props";
+        return !(filesystem::path(cudaPath) / "extras" / "visual_studio_integration" / "MSBuildExtensions" / propsFile).exists();
+    }
+    else {
+        throw std::runtime_error("CUDA_PATH environment variable not set - ");
+    }
+}
+//--------------------------------------------------------------------------
 void Backend::genMakefilePreamble(std::ostream &os, const std::vector<std::string>&) const
 {
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
@@ -397,6 +421,37 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(NVCC) -dc $(NVCCFLAGS) $<" << std::endl;
 }
 //--------------------------------------------------------------------------
+void Backend::genNMakefilePreamble(std::ostream &os) const
+{
+    const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
+    std::string linkFlags = "--shared -arch " + architecture;
+    
+    // Write variables to preamble
+    os << "NVCC = \"$(CUDA_PATH)/bin/nvcc.exe\"" << std::endl;
+    os << "NVCCFLAGS = " << getNVCCFlags() << std::endl;
+    os << "LINKFLAGS = " << linkFlags << std::endl;
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileLinkRule(std::ostream &os) const
+{
+    // Use Visual C++ linker to link objects with device object code
+    // **YUCK** there should be some way to do this with $(CXX) /LINK
+    os << "runner.dll: $(OBJECTS) runner_dlink.obj" << std::endl;
+	os << "\t@link.exe /OUT:runner.dll /LIBPATH:\"$(CUDA_PATH)\\lib\\x64\" cudart_static.lib  cudart.lib cudadevrt.lib /DLL $(OBJECTS) runner_dlink.obj" << std::endl;
+    os << std::endl;
+
+    // Use NVCC to link the device code
+    os << "runner_dlink.obj: $(OBJECTS)" << std::endl;
+	os << "\t@$(NVCC) $(LINKFLAGS) -dlink $(OBJECTS) -o runner_dlink.obj" << std::endl;
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileCompileRule(std::ostream &os) const
+{
+    // Add rule to build object files from cc files
+    os << ".cc.obj:" << std::endl;
+	os << "\t@$(NVCC) -dc $(NVCCFLAGS) $< -o $@" << std::endl;
+}
+//--------------------------------------------------------------------------
 void Backend::genMSBuildConfigProperties(std::ostream &os) const
 {
     // Add property to extract CUDA path
@@ -421,8 +476,8 @@ void Backend::genMSBuildItemDefinitions(std::ostream &os) const
     os << "\t\t\t<Optimization Condition=\"'$(Configuration)'=='Debug'\">Disabled</Optimization>" << std::endl;
     os << "\t\t\t<FunctionLevelLinking Condition=\"'$(Configuration)'=='Release'\">true</FunctionLevelLinking>" << std::endl;
     os << "\t\t\t<IntrinsicFunctions Condition=\"'$(Configuration)'=='Release'\">true</IntrinsicFunctions>" << std::endl;
-    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
-    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
+    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
+    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>" << std::endl;
     os << "\t\t</ClCompile>" << std::endl;
 

--- a/src/genn/backends/cuda/cuda_backend.vcxproj
+++ b/src/genn/backends/cuda/cuda_backend.vcxproj
@@ -48,6 +48,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
+    <CudaLibraryPath Condition=" '$(CudaLibraryPath)' == '' ">$(CUDA_PATH)\lib\$(Platform)</CudaLibraryPath>
     <OutDir>..\..\..\..\lib\</OutDir>
     <IntDir>..\..\..\..\$(Platform)\$(Configuration)\cuda_backend\</IntDir>
     <TargetName>genn_cuda_backend_$(Configuration)</TargetName>
@@ -73,7 +74,7 @@
       <OptimizeReferences Condition=" $(Configuration.Contains('Debug')) ">true</OptimizeReferences>
       <AdditionalDependencies Condition=" '$(Configuration)'=='Release_DLL' ">libffi_Release_DLL.lib;genn_Release_DLL.lib;cudart.lib;cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition=" '$(Configuration)'=='Debug_DLL' ">libffi_Debug_DLL.lib;genn_Debug_DLL.lib;cudart.lib;cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition=" $(Configuration.Contains('DLL')) ">$(OutDir);$(CUDA_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition=" $(Configuration.Contains('DLL')) ">$(OutDir);$(CudaLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -336,9 +336,9 @@ void analyseModule(const Module &module, unsigned int r, CUcontext context,
 
 #ifdef _WIN32
     // **YUCK** extra outer quotes required to workaround gross windowsness https://stackoverflow.com/questions/9964865/c-system-not-working-when-there-are-spaces-in-two-different-parameters
-    const std::string nvccCommand = "\"\"" + nvccPath.str() + "\" -cubin " + backend.getNVCCFlags() + " -DBUILDING_GENERATED_CODE -o \"" + sourcePath + ".cubin\" \"" + sourcePath + "\"\"";
+    const std::string nvccCommand = "\"\"" + nvccPath.str() + "\" -cubin " + backend.getNVCCFlags() + "-o \"" + sourcePath + ".cubin\" \"" + sourcePath + "\"\"";
 #else
-    const std::string nvccCommand = "\"" + nvccPath.str() + "\" -cubin " + backend.getNVCCFlags() + " -DBUILDING_GENERATED_CODE -o \"" + sourcePath + ".cubin\" \"" + sourcePath + "\"";
+    const std::string nvccCommand = "\"" + nvccPath.str() + "\" -cubin " + backend.getNVCCFlags() + " -o \"" + sourcePath + ".cubin\" \"" + sourcePath + "\"";
 #endif
 
     if(system(nvccCommand.c_str()) != 0) {

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -413,78 +413,60 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(HIPCC) -dc $(HIPCCFLAGS) $<" << std::endl;
 }
 //--------------------------------------------------------------------------
+void Backend::genNMakefilePreamble(std::ostream &os) const
+{
+    const std::string architecture = "sm_" + std::to_string(getChosenHIPDevice().major) + std::to_string(getChosenHIPDevice().minor);
+    std::string linkFlags = "--shared -arch " + architecture;
+    
+    // Write variables to preamble
+    os << "HIPCC = \"$(HIP_PATH)/bin/hipcc.exe\"" << std::endl;
+    os << "HIPCCFLAGS = " << getNVCCFlags() << std::endl;
+    os << "LINKFLAGS = " << linkFlags << std::endl;
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileLinkRule(std::ostream &os) const
+{
+    // Use Visual C++ linker to link objects with device object code
+    // **YUCK** there should be some way to do this with $(CXX) /LINK
+    os << "runner.dll: $(OBJECTS) runner_dlink.obj" << std::endl;
+    os << "\t@link.exe /OUT:runner.dll /LIBPATH:\"$(CUDA_PATH)\\lib\\x64\" cudart_static.lib  cudart.lib cudadevrt.lib /DLL $(OBJECTS) runner_dlink.obj" << std::endl;
+    os << std::endl;
+
+    // Use HIPCC to link the device code
+    os << "runner_dlink.obj: $(OBJECTS)" << std::endl;
+    os << "\t@$(HIPCC) $(LINKFLAGS) -dlink $(OBJECTS) -o runner_dlink.obj" << std::endl;
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileCompileRule(std::ostream &os) const
+{
+    // Add rule to build object files from cc files
+    os << ".cc.obj:" << std::endl;
+    os << "\t@$(HIPCC) -dc $(HIPCCFLAGS) $< -o $@" << std::endl;
+}
+//--------------------------------------------------------------------------
 void Backend::genMSBuildConfigProperties(std::ostream&) const
 {
     throw std::runtime_error("The HIP backend does not currently support the MSBuild build system");
-    // Add property to extract CUDA path
-    /*os << "\t\t<!-- **HACK** determine the installed CUDA version by regexing CUDA path -->" << std::endl;
-    os << "\t\t<CudaVersion>$([System.Text.RegularExpressions.Regex]::Match($(CUDA_PATH), \"\\\\v([0-9.]+)$\").Groups[1].Value)</CudaVersion>" << std::endl;*/
 }
 //--------------------------------------------------------------------------
 void Backend::genMSBuildImportProps(std::ostream&) const
 {
     throw std::runtime_error("The HIP backend does not currently support the MSBuild build system");
-    // Import CUDA props file
-    /*os << "\t<ImportGroup Label=\"ExtensionSettings\">" << std::endl;
-    os << "\t\t<Import Project=\"$(CUDA_PATH)\\extras\\visual_studio_integration\\MSBuildExtensions\\CUDA $(CudaVersion).props\" />" << std::endl;
-    os << "\t</ImportGroup>" << std::endl;*/
 }
 //--------------------------------------------------------------------------
 void Backend::genMSBuildItemDefinitions(std::ostream&) const
 {
     throw std::runtime_error("The HIP backend does not currently support the MSBuild build system");
-    // Add item definition for host compilation
-    /*os << "\t\t<ClCompile>" << std::endl;
-    os << "\t\t\t<WarningLevel>Level3</WarningLevel>" << std::endl;
-    os << "\t\t\t<Optimization Condition=\"'$(Configuration)'=='Release'\">MaxSpeed</Optimization>" << std::endl;
-    os << "\t\t\t<Optimization Condition=\"'$(Configuration)'=='Debug'\">Disabled</Optimization>" << std::endl;
-    os << "\t\t\t<FunctionLevelLinking Condition=\"'$(Configuration)'=='Release'\">true</FunctionLevelLinking>" << std::endl;
-    os << "\t\t\t<IntrinsicFunctions Condition=\"'$(Configuration)'=='Release'\">true</IntrinsicFunctions>" << std::endl;
-    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
-    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
-    os << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>" << std::endl;
-    os << "\t\t</ClCompile>" << std::endl;
-
-    // Add item definition for linking
-    os << "\t\t<Link>" << std::endl;
-    os << "\t\t\t<GenerateDebugInformation>true</GenerateDebugInformation>" << std::endl;
-    os << "\t\t\t<EnableCOMDATFolding Condition=\"'$(Configuration)'=='Release'\">true</EnableCOMDATFolding>" << std::endl;
-    os << "\t\t\t<OptimizeReferences Condition=\"'$(Configuration)'=='Release'\">true</OptimizeReferences>" << std::endl;
-    os << "\t\t\t<SubSystem>Console</SubSystem>" << std::endl;
-    os << "\t\t\t<AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>" << std::endl;
-    os << "\t\t</Link>" << std::endl;
-
-    // Add item definition for CUDA compilation
-    // **YUCK** the CUDA Visual Studio plugin build system demands that you specify both a virtual an actual architecture 
-    // (which NVCC itself doesn't require). While, in general, actual architectures are usable as virtual architectures, 
-    // there is no compute_21 so we need to replace that with compute_20
-    const std::string architecture = std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
-    const std::string virtualArchitecture = (architecture == "21") ? "20" : architecture;
-    os << "\t\t<CudaCompile>" << std::endl;
-    os << "\t\t\t<TargetMachinePlatform>64</TargetMachinePlatform>" << std::endl;
-    os << "\t\t\t<GenerateRelocatableDeviceCode>true</GenerateRelocatableDeviceCode>" << std::endl;
-    os << "\t\t\t<CodeGeneration>compute_" << virtualArchitecture <<",sm_" << architecture << "</CodeGeneration>" << std::endl;
-    os << "\t\t\t<FastMath>" << (getPreferences().optimizeCode ? "true" : "false") << "</FastMath>" << std::endl;
-    os << "\t\t\t<GenerateLineInfo>" << (getPreferences<Preferences>().generateLineInfo ? "true" : "false") << "</GenerateLineInfo>" << std::endl;
-    os << "\t\t</CudaCompile>" << std::endl;*/
 }
 //--------------------------------------------------------------------------
 void Backend::genMSBuildCompileModule(const std::string&, std::ostream&) const
 {
     throw std::runtime_error("The HIP backend does not currently support the MSBuild build system");
-    /*os << "\t\t<CudaCompile Include=\"" << moduleName << ".cc\" >" << std::endl;
-    // **YUCK** for some reasons you can't call .Contains on %(BaseCommandLineTemplate) directly
-    // Solution suggested by https://stackoverflow.com/questions/9512577/using-item-functions-on-metadata-values
-    os << "\t\t\t<AdditionalOptions Condition=\" !$([System.String]::new('%(BaseCommandLineTemplate)').Contains('-x cu')) \">-x cu %(AdditionalOptions)</AdditionalOptions>" << std::endl;
-    os << "\t\t</CudaCompile>" << std::endl;*/
 }
 //--------------------------------------------------------------------------
 void Backend::genMSBuildImportTarget(std::ostream&) const
 {
     throw std::runtime_error("The HIP backend does not currently support the MSBuild build system");
-    /*os << "\t<ImportGroup Label=\"ExtensionTargets\">" << std::endl;
-    os << "\t\t<Import Project=\"$(CUDA_PATH)\\extras\\visual_studio_integration\\MSBuildExtensions\\CUDA $(CudaVersion).targets\" />" << std::endl;
-    os << "\t</ImportGroup>" << std::endl;*/
 }
 //--------------------------------------------------------------------------
 boost::uuids::detail::sha1::digest_type Backend::getHashDigest() const

--- a/src/genn/backends/ispc/backend.cc
+++ b/src/genn/backends/ispc/backend.cc
@@ -1035,9 +1035,17 @@ void Backend::genInit(CodeStream &os, FileStreamCreator streamCreator, ModelSpec
     os << initStream.str();
 
 }
-size_t Backend::getSynapticMatrixRowStride(const SynapseGroupInternal &) const
+size_t Backend::getSynapticMatrixRowStride(const SynapseGroupInternal &sg) const
 {
-    return 0;
+    if ((sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE) || (sg.getMatrixType() & SynapseMatrixConnectivity::TOEPLITZ)) {
+        return sg.getMaxConnections();
+    }
+    else if(sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
+        return padSize(sg.getTrgNeuronGroup()->getNumNeurons(), 32);
+    }
+    else {
+        return sg.getTrgNeuronGroup()->getNumNeurons();
+    }
 }
 
 void Backend::genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &) const

--- a/src/genn/backends/ispc/backend.cc
+++ b/src/genn/backends/ispc/backend.cc
@@ -1234,24 +1234,83 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(CXX) $(CXXFLAGS) -MM -o $@ $<" << std::endl;
 }
 
+void Backend::genNMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const
+{
+    // Write variables to preamble
+    os << "CXXFLAGS = /EHsc" << std::endl;
+    os << "ISPCFLAGS = -O2 --dllexport --target=" << getPreferences<Preferences>().targetISA << std::endl;
+
+    // Add ISPC objects
+    os << "OBJECTS = $(OBJECTS) ";
+    for(const auto &m : moduleNames) {
+        if(m != "runner" && m != "init") {
+            os << m << "ISPC.obj ";
+        }
+    }
+    os << std::endl;
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileLinkRule(std::ostream &os) const
+{
+    os << "runner.dll: $(OBJECTS)" << std::endl;
+	os << "\t@link.exe /OUT:runner.dll /DLL $(OBJECTS)" << std::endl;
+    os << std::endl;
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileCompileRule(std::ostream &os) const
+{
+     // Rules for compiling C++ files
+    // **NOTE** needs top depend on ISPC for auto-generated header
+    os << "neuronUpdate.obj: neuronUpdate.cc neuronUpdateISPC.obj" << std::endl;
+    os << "\t@$(CXX) $(CXXFLAGS) /c /Fo$@ neuronUpdate.cc" << std::endl;
+
+    os << "synapseUpdate.obj: synapseUpdate.cc synapseUpdateISPC.obj" << std::endl;
+    os << "\t@$(CXX) $(CXXFLAGS) /c /Fo$@ synapseUpdate.cc" << std::endl;
+
+    os << "customUpdate.obj: customUpdate.cc customUpdateISPC.obj" << std::endl;
+    os << "\t@$(CXX) $(CXXFLAGS) /c /Fo$@ customUpdate.cc" << std::endl;
+
+    os << "init.obj: init.cc" << std::endl;
+    os << "\t@$(CXX) $(CXXFLAGS) /c /Fo$@ init.cc" << std::endl;
+    
+    // Rules for compiling ISPC files
+    // **YUCK** I don't think NMAKE inference rules are smart enough to do this properly
+    os << "neuronUpdateISPC.obj: neuronUpdate.ispc" << std::endl;
+    os << "\t@ispc.exe $(ISPCFLAGS) -o $@ -h neuronUpdateISPC.h neuronUpdate.ispc" << std::endl;
+    os << std::endl;
+
+    os << "synapseUpdateISPC.obj: synapseUpdate.ispc" << std::endl;
+    os << "\t@ispc.exe $(ISPCFLAGS) -o $@ -h synapseUpdateISPC.h synapseUpdate.ispc" << std::endl;
+    os << std::endl;
+
+    os << "customUpdateISPC.obj: customUpdate.ispc" << std::endl;
+    os << "\t@ispc.exe $(ISPCFLAGS) -o $@ -h customUpdateISPC.h customUpdate.ispc" << std::endl;
+    os << std::endl;
+}
+
 void Backend::genMSBuildConfigProperties(std::ostream &) const
 {
+    assert(false);
 }
 
 void Backend::genMSBuildImportProps(std::ostream &) const
 {
+    assert(false);
 }
 
 void Backend::genMSBuildItemDefinitions(std::ostream &) const
 {
+    assert(false);
 }
 
 void Backend::genMSBuildCompileModule(const std::string &, std::ostream &) const
 {
+    assert(false);
 }
 
 void Backend::genMSBuildImportTarget(std::ostream &) const
 {
+    assert(false);
 }
 
 bool Backend::isArrayDeviceObjectRequired() const

--- a/src/genn/backends/ispc/backend.cc
+++ b/src/genn/backends/ispc/backend.cc
@@ -1236,9 +1236,23 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
 
 void Backend::genNMakefilePreamble(std::ostream &os, const std::vector<std::string> &moduleNames) const
 {
+    std::string cxxFlags = "/EHsc";
+    std::string ispcFlags = "-O2 --dllexport --target=" + getPreferences<Preferences>().targetISA;
+    std::string linkFlags = "/DLL";
+    if (getPreferences().optimizeCode) {
+        ispcFlags += " -O3";
+        cxxFlags += " /O2";
+    }
+    if (getPreferences().debugCode) {
+        ispcFlags += " -O0 -g";
+        cxxFlags += " /Od /Zi";
+        linkFlags += " /DEBUG";
+    }
+
     // Write variables to preamble
-    os << "CXXFLAGS = /EHsc" << std::endl;
-    os << "ISPCFLAGS = -O2 --dllexport --target=" << getPreferences<Preferences>().targetISA << std::endl;
+    os << "CXXFLAGS = " << cxxFlags << std::endl;
+    os << "LINKFLAGS = " << linkFlags << std::endl;
+    os << "ISPCFLAGS = " << ispcFlags << std::endl;
 
     // Add ISPC objects
     os << "OBJECTS = $(OBJECTS) ";
@@ -1253,7 +1267,7 @@ void Backend::genNMakefilePreamble(std::ostream &os, const std::vector<std::stri
 void Backend::genNMakefileLinkRule(std::ostream &os) const
 {
     os << "runner.dll: $(OBJECTS)" << std::endl;
-	os << "\t@link.exe /OUT:runner.dll /DLL $(OBJECTS)" << std::endl;
+	os << "\t@link.exe /OUT:runner.dll $(LINKFLAGS) $(OBJECTS)" << std::endl;
     os << std::endl;
 }
 //--------------------------------------------------------------------------

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1678,7 +1678,7 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
 //--------------------------------------------------------------------------
 void Backend::genNMakefilePreamble(std::ostream&) const
 {
-    assert(false)
+    assert(false);
 }
 //--------------------------------------------------------------------------
 void Backend::genNMakefileLinkRule(std::ostream&) const

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1676,6 +1676,21 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(CXX) $(CXXFLAGS) -o $@ $<" << std::endl;
 }
 //--------------------------------------------------------------------------
+void Backend::genNMakefilePreamble(std::ostream&) const
+{
+    assert(false)
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileLinkRule(std::ostream&) const
+{
+    assert(false);
+}
+//--------------------------------------------------------------------------
+void Backend::genNMakefileCompileRule(std::ostream&) const
+{
+    assert(false);
+}
+//--------------------------------------------------------------------------
 void Backend::genMSBuildConfigProperties(std::ostream&) const
 {
 }
@@ -1694,8 +1709,8 @@ void Backend::genMSBuildItemDefinitions(std::ostream &os) const
     os << "\t\t\t<FunctionLevelLinking Condition=\"'$(Configuration)'=='Release'\">true</FunctionLevelLinking>" << std::endl;
     os << "\t\t\t<IntrinsicFunctions Condition=\"'$(Configuration)'=='Release'\">true</IntrinsicFunctions>" << std::endl;
     os << "\t\t\t<ExceptionHandling>SyncCThrow</ExceptionHandling>" << std::endl;
-    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
-    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
+    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
+    os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<FloatingPointModel>" << (getPreferences().optimizeCode ? "Fast" : "Precise") << "</FloatingPointModel>" << std::endl;
     os << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>" << std::endl;
     os << "\t\t</ClCompile>" << std::endl;

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1671,7 +1671,7 @@ void Backend::genMakefileCompileRule(std::ostream &os) const
     os << "\t@$(CXX) $(CXXFLAGS) -o $@ $<" << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genNMakefilePreamble(std::ostream&) const
+void Backend::genNMakefilePreamble(std::ostream&, const std::vector<std::string>&) const
 {
     assert(false);
 }

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1617,11 +1617,6 @@ std::string Backend::getRestrictKeyword() const
     return getHostRestrictKeyword();
 }
 //--------------------------------------------------------------------------
-std::string Backend::getUniformKeyword() const
-{
-    return "";
-}
-//--------------------------------------------------------------------------
 void Backend::genGlobalDeviceRNG(CodeStream&, CodeStream&, CodeStream&, CodeStream&) const
 {
     assert(false);

--- a/src/genn/generator/generator.cc
+++ b/src/genn/generator/generator.cc
@@ -85,7 +85,7 @@ int main(int argc,     //!< number of arguments; expected to be 3
                 CodeGenerator::generateNMakefile(nmake, backend, moduleNames);
             }
             
-            buildCommand = "cd \"" + outputPath.str() + "\" & nmake";
+            buildCommand = "cd \"" + outputPath.str() + "\" & nmake /NOLOGO";
         }
         else {
             // Create MSBuild project to compile and link all generated modules

--- a/src/genn/generator/generator.cc
+++ b/src/genn/generator/generator.cc
@@ -85,7 +85,7 @@ int main(int argc,     //!< number of arguments; expected to be 3
                 CodeGenerator::generateNMakefile(nmake, backend, moduleNames);
             }
             
-            buildCommand = "cd \"" + outputPath.str() + "\" & nmake runner.dll";
+            buildCommand = "cd \"" + outputPath.str() + "\" & nmake";
         }
         else {
             // Create MSBuild project to compile and link all generated modules

--- a/src/genn/generator/generator.vcxproj
+++ b/src/genn/generator/generator.vcxproj
@@ -84,6 +84,9 @@
     <IntDir>$(GeneratePath)\$(Platform)\$(Configuration)\generator\</IntDir>
     <TargetName>$(ProjectName)_$(Configuration)</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition=" $(Configuration.Contains('CUDA')) ">
+    <CudaLibraryPath Condition=" '$(CudaLibraryPath)' == '' ">$(CUDA_PATH)\lib\$(Platform)</CudaLibraryPath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -111,7 +114,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>libffi_Debug.lib;genn_Debug.lib;genn_cuda_backend_Debug.lib;cudart.lib;cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\lib;$(CUDA_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib;$(CudaLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ISPC|x64'">
@@ -164,7 +167,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>libffi_Release.lib;genn_Release.lib;genn_cuda_backend_Release.lib;cudart.lib;cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\lib;$(CUDA_PATH)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib;$(CudaLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_ISPC|x64'">

--- a/src/genn/genn/code_generator/backendCUDAHIP.cc
+++ b/src/genn/genn/code_generator/backendCUDAHIP.cc
@@ -1460,11 +1460,6 @@ std::string BackendCUDAHIP::getRestrictKeyword() const
     return " __restrict__";
 }
 //--------------------------------------------------------------------------
-std::string BackendCUDAHIP::getUniformKeyword() const
-{
-    return "";
-}
-//--------------------------------------------------------------------------
 void BackendCUDAHIP::genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner,
                                         CodeStream &, CodeStream &) const
 {

--- a/src/genn/genn/code_generator/generateMSBuild.cc
+++ b/src/genn/genn/code_generator/generateMSBuild.cc
@@ -12,8 +12,7 @@
 //--------------------------------------------------------------------------
 // GeNN::CodeGenerator
 //--------------------------------------------------------------------------
-void GeNN::CodeGenerator::generateMSBuild(std::ostream &os, const ModelSpecInternal &model, const BackendBase &backend, 
-                                          const std::vector<std::string> &moduleNames)
+void GeNN::CodeGenerator::generateMSBuild(std::ostream &os, const BackendBase &backend, const std::vector<std::string> &moduleNames)
 {
     // Generate header and targets for release and debug builds
     os << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" << std::endl;
@@ -58,8 +57,8 @@ void GeNN::CodeGenerator::generateMSBuild(std::ostream &os, const ModelSpecInter
     // Generate property group configuring build target
     os << "\t<PropertyGroup>" << std::endl;
     os << "\t\t<LinkIncremental Condition=\"'$(Configuration)'=='Debug'\">true</LinkIncremental>" << std::endl;
-    os << "\t\t<OutDir>../</OutDir>" << std::endl;
-    os << "\t\t<TargetName>runner_" << model.getName() << "_$(Configuration)</TargetName>" << std::endl;
+    os << "\t\t<OutDir>./</OutDir>" << std::endl;
+    os << "\t\t<TargetName>runner</TargetName>" << std::endl;
     os << "\t\t<TargetExt>.dll</TargetExt>" << std::endl;
     os << "\t</PropertyGroup>" << std::endl;
 

--- a/src/genn/genn/code_generator/generateNMakefile.cc
+++ b/src/genn/genn/code_generator/generateNMakefile.cc
@@ -1,0 +1,49 @@
+#include "code_generator/generateNMakefile.h"
+
+// Standard C++ includes
+#include <string>
+
+// GeNN includes
+#include "modelSpec.h"
+
+// GeNN code generator includes
+#include "code_generator/backendBase.h"
+
+//--------------------------------------------------------------------------
+// GeNN::CodeGenerator
+//--------------------------------------------------------------------------
+void GeNN::CodeGenerator::generateNMakefile(std::ostream &os, const BackendBase &backend,
+                                            const std::vector<std::string> &moduleNames)
+{
+    // CC isn't a standard suffix so needs specifying
+    os << ".SUFFIXES: .cc" << std::endl;
+
+    // List objects in makefile
+    os << "OBJECTS = ";
+    for(const auto &m : moduleNames) {
+        os << m << ".obj ";
+    }
+    os << std::endl;
+
+    // Generate make file preamble
+    backend.genNMakefilePreamble(os);
+    os << std::endl;
+
+    
+    // Add rule to build runner
+    os << "all: runner.dll" << std::endl;
+    os << std::endl;
+
+    // Add rule to build DLL from objects
+    // **NOTE** because e.g. CUDA requires seperate device linking dependencies not known
+    backend.genNMakefileLinkRule(os);
+    os << std::endl;
+
+    // Generate compile rule build objects from source files
+    backend.genNMakefileCompileRule(os);
+    os << std::endl;
+
+    // Add clean rule
+    os << "clean:" << std::endl;
+    os << "\tdel $(OBJECTS) runner.exp runner.lib runner.dll 2>nul" << std::endl;
+}

--- a/src/genn/genn/code_generator/generateNMakefile.cc
+++ b/src/genn/genn/code_generator/generateNMakefile.cc
@@ -26,7 +26,7 @@ void GeNN::CodeGenerator::generateNMakefile(std::ostream &os, const BackendBase 
     os << std::endl;
 
     // Generate make file preamble
-    backend.genNMakefilePreamble(os);
+    backend.genNMakefilePreamble(os, moduleNames);
     os << std::endl;
 
     

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -51,13 +51,8 @@ void GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath, Mod
     definitions << "#pragma once" << std::endl;
 
 #ifdef _WIN32
-    definitions << "#ifdef BUILDING_GENERATED_CODE" << std::endl;
     definitions << "#define EXPORT_VAR __declspec(dllexport) extern" << std::endl;
     definitions << "#define EXPORT_FUNC __declspec(dllexport)" << std::endl;
-    definitions << "#else" << std::endl;
-    definitions << "#define EXPORT_VAR __declspec(dllimport) extern" << std::endl;
-    definitions << "#define EXPORT_FUNC __declspec(dllimport)" << std::endl;
-    definitions << "#endif" << std::endl;
 #else
     definitions << "#define EXPORT_VAR extern" << std::endl;
     definitions << "#define EXPORT_FUNC" << std::endl;

--- a/src/genn/genn/genn.vcxproj
+++ b/src/genn/genn/genn.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="code_generator\generateModules.cc" />
     <ClCompile Include="code_generator\generateMakefile.cc" />
     <ClCompile Include="code_generator\generateMSBuild.cc" />
+    <ClCompile Include="code_generator\generateNMakefile.cc" />
     <ClCompile Include="code_generator\generateRunner.cc" />
     <ClCompile Include="code_generator\initGroupMerged.cc" />
     <ClCompile Include="code_generator\lazyString.cc" />
@@ -83,6 +84,7 @@
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\generateModules.h" />
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\generateMakefile.h" />
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\generateMSBuild.h" />
+    <ClInclude Include="..\..\..\include\genn\genn\code_generator\generateNMakefile.h" />
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\generateRunner.h" />
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\groupMerged.h" />
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\initGroupMerged.h" />

--- a/src/genn/genn/genn.vcxproj.filters
+++ b/src/genn/genn/genn.vcxproj.filters
@@ -47,6 +47,7 @@
     <ClCompile Include="code_generator\lazyString.cc" />
     <ClCompile Include="runtime\runtime.cc" />
     <ClCompile Include="code_generator\backendCUDAHIP.cc" />
+    <ClCompile Include="code_generator\generateNMakefile.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\include\genn\genn\backendExport.h" />
@@ -111,6 +112,7 @@
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\lazyString.h" />
     <ClInclude Include="..\..\..\include\genn\genn\runtime\runtime.h" />
     <ClInclude Include="..\..\..\include\genn\genn\code_generator\backendCUDAHIP.h" />
+    <ClInclude Include="..\..\..\include\genn\genn\code_generator\generateNMakefile.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="src\header.src" />

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -75,9 +75,7 @@ Runtime::Runtime(const filesystem::path &modelPath, const CodeGenerator::ModelSp
 
     // Load library
 #ifdef _WIN32
-    const std::string runnerName = "runner_" + modelMerged.getModel().getName();
-    const std::string runnerNameSuffix = backend.getPreferences().debugCode ?  "_Debug.dll" :  "_Release.dll";
-    const std::string libraryName = (modelPath / (runnerName + runnerNameSuffix)).str();
+    const std::string libraryName = (modelPath / (modelMerged.getModel().getName() + "_CODE") / "runner.dll").str();
     m_Library = LoadLibrary(libraryName.c_str());
 #else
     const std::string libraryName = (modelPath / (modelMerged.getModel().getName() + "_CODE") / "librunner.so").str();


### PR DESCRIPTION
Made the following fixes and the VA benchmark example now runs correctly:
* Struct members actually didn't need to be uniform at all so I have reverted that change - you just needed to be more careful with ``uniform`` in the surrounding loops
* Init was a bit of a mess. 
  * The serial init code was still being generated in the ispc rather than cc file so didn't work properly as you can't access ``std::random`` etc - I moved it into the .cc file (and fixed the build system so it builds correctly)
  * Various backend methods required for initialisation weren't implemented - I copy-pasted the single-threaded CPU implementations over
* Timers were also a bit of a mess
  * Variables e.g. ``presynapticUpdateTime`` are already declared in runner so you need to ``extern`` them to access those variables from ISPC rather than declare conflicting ones
  * Because the initialisation is now in C++ we need a timer that doesn't use ISPC functionality for these s
* We should be using local rather than global atomics

Also, I was working on integrating a different build system for Windows which works for ISPC so I have cherry-picked that in too meaning you can now work in Windows or Linux.